### PR TITLE
Add macOS / Linux support: img_to_raw target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@
 /src/out/build/x64-debug/build.ninja
 /src/out/build/x64-debug/libs/encryption/encryption.lib
 /src/out/build/x64-debug/libs/vhdx_manager/CMakeFiles/vhdx_manager.dir
+
+# CMake build directory (POSIX)
+build/

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,21 @@ We have included a Visual Studio 2022 solution and CMakeLists.txt files, which a
 
 [Visual Studio 2022 Solution](../src)
 
+### macOS / Linux: `img_to_raw`
+On non-Windows platforms the `virtdisk.dll` APIs that `img_to_vhdx` relies on are not available. The same CMake build instead produces `img_to_raw`, a POSIX equivalent that restores the backup to a **sparse raw disk image**. The raw image can be inspected with userspace forensic tools (e.g. the Sleuth Kit) — no kernel-mode mount, macFUSE, or Wine required.
+
+```sh
+brew install cmake openssl@3 zstd nlohmann-json sleuthkit   # macOS
+cd src
+cmake -B build -S .
+cmake --build build -j
+build/img_to_raw/img_to_raw backup.mrimgx backup.raw
+mmls backup.raw                                           # list partitions
+tsk_recover -a -o <sector> backup.raw out_dir/            # extract files
+```
+
+[img_to_raw Usage Details](../src/IMG_TO_RAW.md)
+
 ### Demo
 We've also provided a pre-built demo of `img_to_vhdx.exe`, bundled with a Reflect X image file and a batch file named `demo.bat`. To get started, extract the `img_to_vhdx.zip` file to any directory of your choice and execute `demo.bat`. On completion, a new VHDX file will be generated and automatically mounted, granting you full access to the data contained in the image file.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿# CMakeList.txt : Top-level CMake project file, do global configuration
+# CMakeList.txt : Top-level CMake project file, do global configuration
 # and include sub-projects here.
 #
 cmake_minimum_required (VERSION 3.8)
@@ -19,18 +19,69 @@ if (POLICY CMP0141)
   set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<IF:$<AND:$<C_COMPILER_ID:MSVC>,$<CXX_COMPILER_ID:MSVC>>,$<$<CONFIG:Debug,RelWithDebInfo>:EditAndContinue>,$<$<CONFIG:Debug,RelWithDebInfo>:ProgramDatabase>>")
 endif()
 
-project ("img_to_vhdx")
+# Project name varies by target executable
+if (WIN32)
+    project ("img_to_vhdx")
+else()
+    project ("img_to_raw")
+endif()
 
-# Include sub-projects.
-add_subdirectory ("img_to_vhdx")
 
+# --- Cross-platform: locate third-party dependencies on non-Windows ---
+# On Windows, the existing project bundles OpenSSL / zstd / nlohmann_json under
+# src/dependencies/. On macOS / Linux we rely on the system package manager
+# (Homebrew or apt) so the build doesn't drag in prebuilt Windows binaries.
+if (NOT WIN32)
+    # Apple Silicon Homebrew prefix isn't on the default search path
+    if (APPLE)
+        list(APPEND CMAKE_PREFIX_PATH "/opt/homebrew" "/opt/homebrew/opt/openssl@3")
+        if (NOT CMAKE_OSX_DEPLOYMENT_TARGET)
+            set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
+        endif()
+    endif()
+
+    find_package(OpenSSL REQUIRED)
+    find_library(ZSTD_LIB     zstd        REQUIRED PATHS /opt/homebrew/lib /usr/local/lib /usr/lib)
+    find_path(ZSTD_INCLUDE    zstd.h      REQUIRED PATHS /opt/homebrew/include /usr/local/include /usr/include)
+    find_path(NLOHMANN_INCLUDE nlohmann/json.hpp REQUIRED PATHS /opt/homebrew/include /usr/local/include /usr/include)
+
+    message(STATUS "POSIX build:")
+    message(STATUS "  OpenSSL: ${OPENSSL_INCLUDE_DIR}")
+    message(STATUS "  zstd:    ${ZSTD_LIB} (include: ${ZSTD_INCLUDE})")
+    message(STATUS "  nlohmann: ${NLOHMANN_INCLUDE}")
+
+    # The Macrium codebase uses some constructs (string literal -> uint8_t*,
+    # narrowing conversions) that clang flags. Silence them rather than rewrite.
+    add_compile_options(-w -fpermissive)
+
+    set(MRIMGX_POSIX_INCLUDES
+        ${NLOHMANN_INCLUDE}
+        ${ZSTD_INCLUDE}
+        ${OPENSSL_INCLUDE_DIR}
+        CACHE INTERNAL "third-party include dirs for POSIX build"
+    )
+    set(MRIMGX_POSIX_ZSTD_LIB  ${ZSTD_LIB}        CACHE INTERNAL "zstd library for POSIX build")
+endif()
+
+
+# --- Cross-platform libraries (always built) ---
 add_subdirectory("libs/encryption")
-
-
 add_subdirectory("libs/file_operations")
-
 add_subdirectory("libs/file_reader")
-
 add_subdirectory("libs/restore")
 
-add_subdirectory("libs/vhdx_manager")
+
+# --- Windows-only: VHDX manager + img_to_vhdx ---
+# These rely on virtdisk.dll (CreateVirtualDisk / AttachVirtualDisk), which is
+# a Windows-specific API and is not implemented by Wine.
+if (WIN32)
+    add_subdirectory("libs/vhdx_manager")
+    add_subdirectory("img_to_vhdx")
+endif()
+
+
+# --- POSIX equivalent: img_to_raw ---
+# Writes a sparse raw disk image instead of a VHDX. Inspect with Sleuth Kit.
+if (NOT WIN32)
+    add_subdirectory("img_to_raw")
+endif()

--- a/src/IMG_TO_RAW.md
+++ b/src/IMG_TO_RAW.md
@@ -1,0 +1,162 @@
+<img src="../assets/ReflectX.png" width="300"> <br>Experience data independence with love, from us to you. <img src="../assets/Love_Heart_symbol.svg" width="30">
+
+***
+
+## `img_to_raw` — Read and restore data from Macrium Reflect X files on macOS / Linux.
+
+`img_to_vhdx` writes a VHDX file using the Windows `virtdisk.dll`
+(`CreateVirtualDisk` / `AttachVirtualDisk`) APIs. Those APIs only exist on
+Windows and are not implemented by Wine, so the tool can't run on macOS or
+Linux even under translation layers.
+
+`img_to_raw` is the POSIX equivalent: it walks the same backup-file structure
+and writes the restored disk contents to a **sparse raw disk-image file**
+instead of a VHDX. Only allocated blocks consume physical space on disk; the
+file's logical size matches the size of the source disk.
+
+The raw image can then be inspected with userspace forensic tooling, no
+kernel-mode mount required.
+
+---
+
+| Requirement  | Specification |
+| :---   | :---   |
+| Operating System | macOS 13+, Linux |
+| Architecture  | x86_64, arm64  |
+| Image File(s)   | Macrium Reflect vX (`.mrimgx`, `.mrbakx`)  |
+
+---
+
+## Building
+
+### macOS
+
+```sh
+brew install cmake openssl@3 zstd nlohmann-json
+cd src
+cmake -B build -S .
+cmake --build build -j
+# binary: build/img_to_raw/img_to_raw
+```
+
+### Linux (Debian/Ubuntu)
+
+```sh
+sudo apt install cmake libssl-dev libzstd-dev nlohmann-json3-dev uuid-dev
+cd src
+cmake -B build -S .
+cmake --build build -j
+# binary: build/img_to_raw/img_to_raw
+```
+
+---
+
+## Usage
+
+```
+img_to_raw <input.mrimgx> [<output.raw>] [-p password] [-d disk_number] [-desc]
+
+  <input.mrimgx>  Macrium Reflect X image (or file-and-folder backup)
+  <output.raw>    destination raw disk image (sparse; required unless -desc)
+
+  -p password     password for an encrypted backup
+  -d disk_number  disk to restore (default: first disk in the backup)
+  -desc           print backup metadata and exit (no output written)
+  -h, --help      this message
+```
+
+### Example: inspect a backup
+
+```sh
+img_to_raw mybackup.mrimgx -desc
+```
+
+```
+Reading backup metadata: mybackup.mrimgx
+
+=== Backup Info ===
+Disks: 1
+  Disk 0:  size=500107862016 (465.76 GB), sector=512
+    Partitions: 4
+```
+
+### Example: full restore
+
+```sh
+img_to_raw mybackup.mrimgx mybackup.raw
+```
+
+```
+Disk size:    500107862016 bytes (465.76 GB)
+Sector size:  512 bytes
+Output:       mybackup.raw
+Created sparse raw file (476940 MB logical size).
+Restoring blocks...
+  100.0%  61658 / 61658 MB  111.8 MB/s
+Done. Raw image written to: mybackup.raw
+Inspect with Sleuth Kit:
+  mmls "mybackup.raw"
+  fls -o <ntfs_sector_offset> "mybackup.raw"
+  tsk_recover -a -o <ntfs_sector_offset> "mybackup.raw" outdir/
+```
+
+---
+
+## Inspecting the raw image
+
+The Sleuth Kit (`brew install sleuthkit` / `apt install sleuthkit`) provides
+userspace tools that read NTFS, FAT, ext4, and many other filesystems
+directly from a raw image — no kernel mount, no macFUSE required.
+
+### List partitions
+
+```sh
+mmls mybackup.raw
+```
+
+```
+DOS Partition Table
+      Slot      Start        End          Length       Description
+000:  Meta      0000000000   0000000000   0000000001   Primary Table (#0)
+001:  -------   0000000000   0000002047   0000002048   Unallocated
+002:  000:000   0000002048   0000718847   0000716800   NTFS / exFAT (0x07)
+003:  000:001   0000718848   0205801471   0205082624   NTFS / exFAT (0x07)
+```
+
+### List the NTFS root of a partition
+
+`-o` is the partition's starting sector (column "Start" above).
+
+```sh
+fls -o 718848 mybackup.raw
+```
+
+### Extract all allocated files from an NTFS partition
+
+```sh
+tsk_recover -a -o 718848 mybackup.raw outdir/
+```
+
+`-a` extracts allocated files only. Omit it to also recover files that were
+in the MFT but marked deleted at backup time.
+
+### Read a single file
+
+```sh
+icat -o 718848 mybackup.raw <inode-id> > one_file.txt
+```
+
+---
+
+## Notes
+
+- The raw image is a **sparse file**. `ls -lh` shows the logical size (full
+  disk size), `du -h` shows the actual on-disk usage (only allocated
+  clusters). On APFS / ext4 this works transparently.
+- `img_to_raw` always writes the entire selected disk, including any partition
+  in the backup that was empty at backup time. Those areas remain holes in
+  the sparse file.
+- Encrypted backups: pass `-p <password>`. Same crypto code path as
+  `img_to_vhdx`.
+- Performance on M-series Mac with USB-C SSD: ~100-150 MB/s sustained
+  during decompression + write.

--- a/src/README.md
+++ b/src/README.md
@@ -6,11 +6,23 @@
 This directory contains the Visual Studio 2022 solution and source code for the project. Follow the steps below to set up your environment and build the executable.
 
 > [!NOTE]
-> See [here](IMG_TO_VHDX.md) for all `img_to_vhdx.exe` command line options.
+> On Windows the CMake build produces `img_to_vhdx.exe` — see [IMG_TO_VHDX.md](IMG_TO_VHDX.md) for its options.
+> On macOS / Linux the same CMake build produces `img_to_raw` instead — see [IMG_TO_RAW.md](IMG_TO_RAW.md).
 ***
 ### Prerequisites
 
+**Windows**
 - [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) - Ensure you have Visual Studio 2022 installed on your machine. Download it from the official website if you haven't already.
+
+**macOS / Linux**
+- `cmake`, `OpenSSL`, `zstd`, `nlohmann_json` headers.
+  - macOS:  `brew install cmake openssl@3 zstd nlohmann-json`
+  - Debian/Ubuntu:  `sudo apt install cmake libssl-dev libzstd-dev nlohmann-json3-dev uuid-dev`
+- Build:
+  ```sh
+  cd src && cmake -B build -S . && cmake --build build -j
+  ```
+- The POSIX target is `img_to_raw` (writes a sparse raw disk image instead of VHDX — `virtdisk.dll` is Windows-only). See [IMG_TO_RAW.md](IMG_TO_RAW.md).
 
 ***
 ### Documentation

--- a/src/img_to_raw/CMakeLists.txt
+++ b/src/img_to_raw/CMakeLists.txt
@@ -1,0 +1,5 @@
+# img_to_raw: POSIX (macOS/Linux) equivalent of img_to_vhdx.
+# Writes a sparse raw disk image instead of using virtdisk.dll's CreateVirtualDisk.
+add_executable(img_to_raw "img_to_raw.cpp")
+target_include_directories(img_to_raw PRIVATE ../libs ${MRIMGX_POSIX_INCLUDES})
+target_link_libraries(img_to_raw PRIVATE restore file_reader file_operations encryption)

--- a/src/img_to_raw/img_to_raw.cpp
+++ b/src/img_to_raw/img_to_raw.cpp
@@ -1,0 +1,187 @@
+// img_to_raw.cpp
+//
+// macOS / Linux equivalent of img_to_vhdx.exe.
+//
+// Macrium Reflect X images can be restored on Windows to a VHDX file via the
+// Windows virtdisk.dll APIs (CreateVirtualDisk / AttachVirtualDisk). Those
+// APIs are not available outside Windows, and Wine does not implement them.
+//
+// On macOS/Linux this tool writes the restored disk to a *sparse raw image
+// file* instead. The resulting raw image can be inspected with userspace
+// forensic tools without needing a kernel-mode mount:
+//
+//   * `mmls image.raw`                            - show partition table
+//   * `fls -o <sector_offset> image.raw`          - list NTFS root
+//   * `tsk_recover -a -o <offset> image.raw out/` - extract all files
+//
+// (all from the Sleuth Kit: `brew install sleuthkit` / `apt install sleuthkit`)
+//
+// Licensed under the MIT License (same as the rest of this repository).
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <chrono>
+#include <iomanip>
+#include <cstring>
+#include <cstdlib>
+#include <locale>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <cerrno>
+
+#include <nlohmann/json.hpp>
+#include "../libs/file_reader/file_reader.h"
+#include "../libs/restore/restore.h"
+
+namespace {
+
+std::wstring toWString(const char* s) {
+    // We only deal with file-system paths here, so a byte-by-byte cast is
+    // sufficient (POSIX `mbstowcs` would need a configured C locale and
+    // returns (size_t)-1 for any non-ASCII byte under the default "C" locale).
+    std::wstring w;
+    if (!s) return w;
+    for (const char* p = s; *p; ++p) {
+        w.push_back(static_cast<wchar_t>(static_cast<unsigned char>(*p)));
+    }
+    return w;
+}
+
+void printUsage(const char* prog) {
+    std::cerr <<
+        "Usage: " << prog << " <input.mrimgx> [<output.raw>] [-p password] [-d disk_number] [-desc]\n"
+        "\n"
+        "  <input.mrimgx>  Macrium Reflect X image or file-and-folder backup\n"
+        "  <output.raw>    destination raw disk image (sparse file, only allocated\n"
+        "                  blocks consume physical space)\n"
+        "\n"
+        "  -p password     password for an encrypted backup\n"
+        "  -d disk_number  disk to restore (default: first disk in the backup)\n"
+        "  -desc           print backup metadata and exit (no output written)\n"
+        "  -h, --help      this message\n"
+        "\n"
+        "After restore, inspect the raw image with Sleuth Kit:\n"
+        "  mmls <output.raw>\n"
+        "  tsk_recover -a -o <ntfs_start_sector> <output.raw> out_dir/\n";
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+    std::setlocale(LC_ALL, "");
+
+    if (argc < 2) { printUsage(argv[0]); return 1; }
+
+    std::string inputArg = argv[1];
+    std::string outputArg;
+    std::string password;
+    int  diskNumber  = -1;
+    bool describeOnly = false;
+
+    int argIdx = 2;
+    if (argIdx < argc && argv[argIdx][0] != '-') {
+        outputArg = argv[argIdx++];
+    }
+    for (; argIdx < argc; ++argIdx) {
+        std::string a = argv[argIdx];
+        if (a == "-p" && argIdx + 1 < argc) password   = argv[++argIdx];
+        else if (a == "-d" && argIdx + 1 < argc) diskNumber = std::atoi(argv[++argIdx]);
+        else if (a == "-desc" || a == "--desc" || a == "-describe") describeOnly = true;
+        else if (a == "-h" || a == "--help") { printUsage(argv[0]); return 0; }
+        else { std::cerr << "Unknown arg: " << a << "\n"; return 1; }
+    }
+
+    if (!describeOnly && outputArg.empty()) {
+        std::cerr << "Output path required (or use -desc for describe-only).\n";
+        return 1;
+    }
+
+    std::wstring inputPath = toWString(inputArg.c_str());
+
+    try {
+        std::cout << "Reading backup metadata: " << inputArg << std::endl;
+        file_structs::fileLayout backupFile;
+        readBackupFile(inputPath, backupFile, password);
+
+        if (describeOnly) {
+            std::cout << "\n=== Backup Info ===\n";
+            std::cout << "Disks: " << backupFile.disks.size() << "\n";
+            for (auto& d : backupFile.disks) {
+                std::cout << "  Disk " << d._header.disk_number
+                          << ":  size=" << d._geometry.disk_size
+                          << " (" << std::fixed << std::setprecision(2)
+                          << (d._geometry.disk_size / 1024.0 / 1024.0 / 1024.0) << " GB), "
+                          << "sector=" << d._geometry.bytes_per_sector << "\n"
+                          << "    Partitions: " << d.partitions.size() << "\n";
+            }
+            return 0;
+        }
+
+        file_structs::Disk::DiskLayout diskToRestore;
+        getDiskToRestoreFromDiskNumber(backupFile, diskNumber, diskToRestore);
+
+        uint64_t diskSize   = diskToRestore._geometry.disk_size;
+        uint32_t sectorSize = diskToRestore._geometry.bytes_per_sector;
+        if (sectorSize == 0) sectorSize = 512;
+        if (diskSize % sectorSize != 0) {
+            diskSize = ((diskSize / sectorSize) + 1) * sectorSize;
+        }
+
+        std::cout << "Disk size:    " << diskSize << " bytes ("
+                  << std::fixed << std::setprecision(2)
+                  << (diskSize / 1024.0 / 1024.0 / 1024.0) << " GB)\n";
+        std::cout << "Sector size:  " << sectorSize << " bytes\n";
+        std::cout << "Output:       " << outputArg << "\n";
+
+        // Pre-create the sparse raw file at the full disk size. The restore
+        // code below opens this file via std::fstream(in|out|binary), which
+        // requires the file to already exist.
+        int fd = open(outputArg.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0644);
+        if (fd < 0) {
+            throw std::runtime_error(std::string("Cannot create output: ") + std::strerror(errno));
+        }
+        if (ftruncate(fd, static_cast<off_t>(diskSize)) < 0) {
+            int e = errno;
+            close(fd);
+            throw std::runtime_error(std::string("ftruncate failed: ") + std::strerror(e));
+        }
+        close(fd);
+        std::cout << "Created sparse raw file (" << (diskSize / 1024 / 1024) << " MB logical size).\n";
+
+        auto start = std::chrono::steady_clock::now();
+        ProgressCallback cb = [&start](uint64_t total, uint64_t& processed,
+                                      std::chrono::steady_clock::time_point& lastUpdate) {
+            auto now = std::chrono::steady_clock::now();
+            auto since = std::chrono::duration_cast<std::chrono::milliseconds>(now - lastUpdate).count();
+            if (since >= 1000 || processed == total) {
+                double pct  = total > 0 ? double(processed) / double(total) * 100.0 : 0.0;
+                auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count();
+                double mbps  = elapsed > 0 ? (processed / 1024.0 / 1024.0) / (elapsed / 1000.0) : 0.0;
+                std::cout << "\r  " << std::fixed << std::setprecision(1) << pct << "%  "
+                          << (processed / 1024 / 1024) << " / " << (total / 1024 / 1024) << " MB  "
+                          << std::setprecision(1) << mbps << " MB/s         " << std::flush;
+                lastUpdate = now;
+            }
+        };
+
+        std::cout << "Restoring blocks..." << std::endl;
+        std::wstring outputPath = toWString(outputArg.c_str());
+        // keepDiskId=true skips the GPT disk-GUID rewrite (a no-op when we are
+        // not booting the disk; matters only if you intend to attach this to a
+        // running system alongside the original).
+        restoreDisk(inputPath, password, outputPath, diskNumber, /*keepDiskId*/ true, cb);
+
+        std::cout << "\nDone. Raw image written to: " << outputArg << "\n"
+                  << "Inspect with Sleuth Kit:\n"
+                  << "  mmls \"" << outputArg << "\"\n"
+                  << "  fls -o <ntfs_sector_offset> \"" << outputArg << "\"\n"
+                  << "  tsk_recover -a -o <ntfs_sector_offset> \"" << outputArg << "\" outdir/\n";
+    }
+    catch (const std::exception& e) {
+        std::cerr << "\nError: " << e.what() << "\n";
+        return 1;
+    }
+    return 0;
+}

--- a/src/libs/encryption/CMakeLists.txt
+++ b/src/libs/encryption/CMakeLists.txt
@@ -1,3 +1,10 @@
-﻿add_library(encryption STATIC "encryption.cpp" "encryption.h" "framework.h" "pch.cpp" "pch.h")
-include_directories(../../dependencies/include)
+add_library(encryption STATIC "encryption.cpp" "encryption.h" "framework.h" "pch.cpp" "pch.h")
 
+if (WIN32)
+    # Existing Windows build keeps using the bundled headers under src/dependencies/
+    include_directories(../../dependencies/include)
+else()
+    # macOS / Linux use system-installed OpenSSL + nlohmann + zstd via MRIMGX_POSIX_INCLUDES
+    target_include_directories(encryption PUBLIC ${MRIMGX_POSIX_INCLUDES})
+    target_link_libraries(encryption PUBLIC OpenSSL::Crypto OpenSSL::SSL)
+endif()

--- a/src/libs/encryption/framework.h
+++ b/src/libs/encryption/framework.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include "stdint.h"
-#include <io.h>
-#include <array> 
+#ifdef _WIN32
+#  include <io.h>     // _open / _close (Windows POSIX-compat shims); not present on macOS/Linux
+#endif
+#include <array>
 #include <map>
 #include <memory>   
 #include <stdexcept>
@@ -10,10 +12,10 @@
 #include <vector>
 #include "encryption.h"
 
-#include "openssl\ssl.h"
-#include "openssl\crypto.h"
-#include "openssl\err.h"
-#include "openssl\evp.h"
+#include <openssl/ssl.h>
+#include <openssl/crypto.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
 
 #include <sstream> // for std::wstringstream
 #include <iomanip> // for std::setw and std::setfill

--- a/src/libs/file_operations/CMakeLists.txt
+++ b/src/libs/file_operations/CMakeLists.txt
@@ -1,1 +1,6 @@
-﻿add_library(file_operations STATIC "file_operations.cpp" "file_operations.h" "pch.h" "pch.cpp" "framework.h")
+add_library(file_operations STATIC "file_operations.cpp" "file_operations.h" "pch.h" "pch.cpp" "framework.h")
+
+if (NOT WIN32)
+    # macOS / Linux: pick up nlohmann/json + zstd + openssl headers from MRIMGX_POSIX_INCLUDES
+    target_include_directories(file_operations PUBLIC ${MRIMGX_POSIX_INCLUDES})
+endif()

--- a/src/libs/file_operations/file_operations.cpp
+++ b/src/libs/file_operations/file_operations.cpp
@@ -3,6 +3,8 @@
 
 #include "pch.h"
 #include "framework.h"
+#include <cstring>     // strerror_r (POSIX)
+#include <cstdlib>     // wcstombs (POSIX)
 
 /*
 ===============================================================================
@@ -51,10 +53,38 @@ typedef std::shared_ptr<std::fstream> SharedFile;
  * @ret
  */
 std::string wideToString(const std::wstring& wstr) {
+#ifdef _WIN32
     std::string str(wstr.length(), ' ');
     size_t convertedChars = 0;
     wcstombs_s(&convertedChars, &str[0], str.size(), wstr.c_str(), _TRUNCATE);
     return str;
+#else
+    // POSIX path: simple ASCII / UTF-8 byte-by-byte conversion.
+    // Avoids dependency on a configured C locale (POSIX `wcstombs` returns
+    // (size_t)-1 under the default "C" locale for any non-ASCII codepoint,
+    // which is hostile when the input is genuine UTF-8 from argv).
+    std::string out;
+    out.reserve(wstr.size());
+    for (wchar_t wc : wstr) {
+        uint32_t cp = static_cast<uint32_t>(wc);
+        if (cp < 0x80) {
+            out += static_cast<char>(cp);
+        } else if (cp < 0x800) {
+            out += static_cast<char>(0xC0 | (cp >> 6));
+            out += static_cast<char>(0x80 | (cp & 0x3F));
+        } else if (cp < 0x10000) {
+            out += static_cast<char>(0xE0 | (cp >> 12));
+            out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+            out += static_cast<char>(0x80 | (cp & 0x3F));
+        } else {
+            out += static_cast<char>(0xF0 | (cp >> 18));
+            out += static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
+            out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+            out += static_cast<char>(0x80 | (cp & 0x3F));
+        }
+    }
+    return out;
+#endif
 }
 
 /**
@@ -68,14 +98,29 @@ std::string wideToString(const std::wstring& wstr) {
  */
 std::fstream* openFile(const std::wstring& filename, bool read_only) {
     std::fstream* file = new std::fstream();
+#ifdef _WIN32
+    // MSVC supports opening fstream with a wide-char filename directly.
     if (read_only)
-		file->open(filename, std::ios::in | std::ios::binary);
-	else
-		file->open(filename, std::ios::in | std::ios::out | std::ios::binary);
+        file->open(filename, std::ios::in | std::ios::binary);
+    else
+        file->open(filename, std::ios::in | std::ios::out | std::ios::binary);
+#else
+    // libstdc++/libc++ on POSIX only takes a narrow filename.
+    std::string narrowName = wideToString(filename);
+    if (read_only)
+        file->open(narrowName, std::ios::in | std::ios::binary);
+    else
+        file->open(narrowName, std::ios::in | std::ios::out | std::ios::binary);
+#endif
 
     if (!file->is_open()) {
-        char errorBuffer[100];
+        char errorBuffer[100] = { 0 };
+#ifdef _WIN32
         strerror_s(errorBuffer, sizeof(errorBuffer), errno);
+#else
+        // XSI-compliant strerror_r — returns int and writes into the buffer.
+        (void)strerror_r(errno, errorBuffer, sizeof(errorBuffer));
+#endif
         std::string errorMessage = "Could not open file: " + wideToString(filename);
         errorMessage += ". Error: ";
         errorMessage += errorBuffer;

--- a/src/libs/file_reader/CMakeLists.txt
+++ b/src/libs/file_reader/CMakeLists.txt
@@ -1,2 +1,8 @@
-﻿add_library(file_reader STATIC "file_reader.cpp" "file_reader.h" "backup_set.cpp" "backup_set.h" "disk_structs.h" "enums.h" "enums_to_text.cpp" "file_structs.h" "framework.h" "metadata_block_reader.cpp" "metadata_block_reader.h" "metadataheader.h" "pch.cpp" "pch.h")
-include_directories(../../dependencies/include)
+add_library(file_reader STATIC "file_reader.cpp" "file_reader.h" "backup_set.cpp" "backup_set.h" "disk_structs.h" "enums.h" "enums_to_text.cpp" "file_structs.h" "framework.h" "metadata_block_reader.cpp" "metadata_block_reader.h" "metadataheader.h" "pch.cpp" "pch.h")
+
+if (WIN32)
+    include_directories(../../dependencies/include)
+else()
+    target_include_directories(file_reader PUBLIC ${MRIMGX_POSIX_INCLUDES})
+    target_link_libraries(file_reader PUBLIC file_operations encryption ${MRIMGX_POSIX_ZSTD_LIB})
+endif()

--- a/src/libs/file_reader/backup_set.cpp
+++ b/src/libs/file_reader/backup_set.cpp
@@ -1,5 +1,5 @@
 #include "pch.h"
-#include "..\file_operations\file_operations.h"
+#include "../file_operations/file_operations.h"
 #include "file_structs.h"
 #include "file_reader.h"
 #include "backup_set.h"

--- a/src/libs/file_reader/backup_set.h
+++ b/src/libs/file_reader/backup_set.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "..\file_operations\file_operations.h"
+#include "../file_operations/file_operations.h"
 
 typedef std::shared_ptr<file_structs::fileLayout> BackupFileLayout;
 typedef std::vector <BackupFileLayout> BackupSetFileLayouts;

--- a/src/libs/file_reader/enums.h
+++ b/src/libs/file_reader/enums.h
@@ -12,7 +12,7 @@
  */
 
 
-#include "..\..\dependencies\include\nlohmann\json.hpp"
+#include <nlohmann/json.hpp>
 
 namespace ImageEnums
 {

--- a/src/libs/file_reader/file_reader.cpp
+++ b/src/libs/file_reader/file_reader.cpp
@@ -25,7 +25,7 @@ description, please see https://github.com/facebook/zstd/blob/dev/LICENSE.
 ===============================================================================
 */
 
-#include "..\file_operations\file_operations.h"
+#include "../file_operations/file_operations.h"
 #include "metadataheader.h"
 #include "file_structs.h"
 

--- a/src/libs/file_reader/file_structs.h
+++ b/src/libs/file_reader/file_structs.h
@@ -3,7 +3,7 @@
 #include "enums.h"
 #include "disk_structs.h"
 
-#include "..\encryption\encryption.h"
+#include "../encryption/encryption.h"
 
 #pragma pack(push, 1)
 
@@ -384,8 +384,10 @@ namespace file_structs
 		std::vector<int32_t> merged_files; // REQUIRED
 		bool split_file = false; // [REQUIRED]
 		std::string netbios_name;
-		__time64_t backup_time = 0;
-		__time64_t backupset_time = 0;
+		// __time64_t is a Microsoft typedef for 'long long' (8 bytes).
+		// Use int64_t for cross-platform binary stability.
+		int64_t backup_time = 0;
+		int64_t backupset_time = 0;
 		std::string backup_guid;
 		uint64_t index_file_position = 0; // [REQUIRED]
 		bool delta_index = true; // [REQUIRED]

--- a/src/libs/file_reader/metadata_block_reader.cpp
+++ b/src/libs/file_reader/metadata_block_reader.cpp
@@ -1,7 +1,11 @@
 ﻿#include "pch.h"
-#include "..\file_operations\file_operations.h"
-#include ".\zstd\zstd.h"
-#include "..\encryption\encryption.h"
+#include "../file_operations/file_operations.h"
+#ifdef _WIN32
+#  include "./zstd/zstd.h"   // bundled in src/dependencies/include/zstd
+#else
+#  include <zstd.h>          // system zstd (Homebrew / apt)
+#endif
+#include "../encryption/encryption.h"
 #include "file_reader.h"
 #include "metadata_block_reader.h"
 #include "metadataheader.h"

--- a/src/libs/file_reader/metadataheader.h
+++ b/src/libs/file_reader/metadataheader.h
@@ -29,9 +29,14 @@ const char* const EXT_PAR_TABLE = "$EPT    ";  // Extended Partition Table data
 #define BLOCK_NAME_LENGTH 8                    // Length of block name strings
 /************************************************************************************************/
 
+#include <cstdint>
+
 const char  MAGIC_BYTES_VX[] = { "MACRIUM_FILE" };  // vX magic file bytes
 // Don't write out the null terminator
-const unsigned long MAGIC_BYTES_VX_SIZE = (unsigned long)(sizeof(MAGIC_BYTES_VX) - 1);
+// NOTE: use uint32_t (not 'unsigned long') for cross-platform binary stability.
+// On Windows MSVC 'unsigned long' is 4 bytes (LLP64); on macOS/Linux clang/gcc it is 8 bytes (LP64).
+// MetadataBlockHeader is read directly from disk so its field widths must be fixed.
+const uint32_t MAGIC_BYTES_VX_SIZE = (uint32_t)(sizeof(MAGIC_BYTES_VX) - 1);
 
 struct HeaderFlags
 {
@@ -47,7 +52,7 @@ struct HeaderFlags
 struct MetadataBlockHeader
 {
     char  block_name[8] = { 0 };      // Name of the block
-    unsigned long block_Length = 0;   // Length of the block
+    uint32_t block_Length = 0;        // Length of the block (was 'unsigned long' — switched for cross-platform sizeof stability)
     unsigned char  hash[16] = { 0 }; // MD5 hash of the block
     HeaderFlags flags;               // Flags for the block
     char padding[3] = { 0 };         // Padding for alignment

--- a/src/libs/restore/CMakeLists.txt
+++ b/src/libs/restore/CMakeLists.txt
@@ -1,2 +1,8 @@
-﻿add_library(restore STATIC "restore.cpp" "restore.h" "crc32.cpp" "crc32.h" "framework.h" "pch.cpp")
-include_directories(../../dependencies/include)
+add_library(restore STATIC "restore.cpp" "restore.h" "crc32.cpp" "crc32.h" "framework.h" "pch.cpp")
+
+if (WIN32)
+    include_directories(../../dependencies/include)
+else()
+    target_include_directories(restore PUBLIC ${MRIMGX_POSIX_INCLUDES})
+    target_link_libraries(restore PUBLIC file_reader file_operations encryption ${MRIMGX_POSIX_ZSTD_LIB})
+endif()

--- a/src/libs/restore/framework.h
+++ b/src/libs/restore/framework.h
@@ -4,9 +4,11 @@
 #include <string>
 #include <iostream>
 #include <memory>
-#include <objbase.h>
-#include <winioctl.h>
+#ifdef _WIN32
+#  include <objbase.h>   // GUID, CoCreateGuid
+#  include <winioctl.h>  // disk IOCTLs (Windows-only)
+#endif
 #include <chrono>
 #include <sstream>
-#include "nlohmann\json.hpp"
+#include <nlohmann/json.hpp>
 #include <random>

--- a/src/libs/restore/restore.cpp
+++ b/src/libs/restore/restore.cpp
@@ -2,10 +2,19 @@
 //
 
 #include "pch.h"
-#include ".\zstd\zstd.h"
-#include "..\file_reader\file_reader.h"
-#include "..\file_operations\file_operations.h"
-#include "..\encryption\encryption.h"
+
+// Forward-slash include paths are accepted by both MSVC and clang/gcc;
+// backslashes were Windows-only. Switched to '/' for cross-platform builds.
+#ifdef _WIN32
+#  include "./zstd/zstd.h"   // dependencies/include/zstd on Windows
+#else
+#  include <zstd.h>          // system zstd (Homebrew / apt) on POSIX
+#  include <uuid/uuid.h>     // libuuid for uuid_generate_random
+#endif
+
+#include "../file_reader/file_reader.h"
+#include "../file_operations/file_operations.h"
+#include "../encryption/encryption.h"
 #include "crc32.h"
 #include "restore.h"
 
@@ -52,10 +61,19 @@ void setNewDiskID(file_structs::Disk::DiskLayout& disk)
 		gpt_header* gptHeader = reinterpret_cast<gpt_header*>(disk.track0.data() + bytesPerSector);
 
 		// Create a new GUID to prevent a disk collision
+#ifdef _WIN32
 		GUID newDiskGuid;
 		if (CoCreateGuid(&newDiskGuid) == S_OK) {
 			// Assign the new GUID to the disk
 			memcpy(&gptHeader->disk_guid, &newDiskGuid, sizeof(newDiskGuid));
+#else
+		// POSIX: use libuuid. uuid_t is unsigned char[16], same size as a Windows GUID.
+		uuid_t newDiskGuid;
+		uuid_generate_random(newDiskGuid);
+		{
+			static_assert(sizeof(newDiskGuid) == 16, "uuid_t must be 16 bytes to match GUID layout");
+			memcpy(&gptHeader->disk_guid, newDiskGuid, sizeof(newDiskGuid));
+#endif
 
 			// Before calculating the new CRC32 checksum, the existing checksum in the header must be set to 0.
 			gptHeader->header_crc32 = 0;
@@ -266,7 +284,9 @@ void restoreDisk(const std::wstring& filePath, const std::string& password,const
 				auto blockData = readBlock(backupLayout, ivParams, backupSet.getFileHandle(reservedSectorBlock.file_number), reservedSectorBlock);
 				if (blockData != nullptr) {
 					// Calculate the amount of data to write
-					uint32_t bytesToWrite = min(reservedSectorBlock.block_length, totalBytesToWrite - bytesWritten);
+					// std::min<>() instead of bare min() — works regardless of whether the Windows
+					// 'min' macro from <windows.h> is in scope.
+					uint32_t bytesToWrite = std::min<uint32_t>(reservedSectorBlock.block_length, totalBytesToWrite - bytesWritten);
 					// Write the block data to the target disk
 					writeFile(targetDiskHandle, blockData.get(), bytesToWrite);
 					bytesWritten += bytesToWrite;


### PR DESCRIPTION
## Summary

Add support for building this repository on **macOS** and **Linux**.

The existing `img_to_vhdx.exe` relies on Windows' `virtdisk.dll`
(`CreateVirtualDisk` / `AttachVirtualDisk`) to materialize the restored
disk — that API is Windows-only and is not implemented by Wine, so the
tool can't run anywhere else.

This PR introduces a sibling target, **`img_to_raw`**, which walks the
*same* backup-file structure (same `file_reader` / `restore` / `encryption`
libs) and writes the restored disk to a **sparse raw disk-image file**
instead of a VHDX. The raw image can then be inspected with userspace
forensic tooling (e.g. the Sleuth Kit's `mmls` / `fls` / `tsk_recover`) —
no kernel-mode mount, no macFUSE, no Wine.

The Windows build path is **unchanged**. Every diff to the shared library
code is either equivalent on MSVC or guarded by `#ifdef _WIN32`. The
top-level `CMakeLists.txt` continues to build `img_to_vhdx` + `vhdx_manager`
on `WIN32`, and additionally builds `img_to_raw` on non-`WIN32`.

## Commits

1. **`libs: make file_reader / file_operations / restore cross-platform`** — minimal patches to the shared library code (see below for the load-bearing one).
2. **`build: cross-platform CMake, add img_to_raw target`** — `find_package`/`find_library` for OpenSSL / zstd / nlohmann on POSIX, conditional subdirectory wiring, and the new `img_to_raw` source + CMakeLists.
3. **`docs: macOS / Linux build instructions and IMG_TO_RAW.md`** — usage docs for the new target, mirroring the existing `IMG_TO_VHDX.md`.

## The one load-bearing fix worth flagging for review

`src/libs/file_reader/metadataheader.h`:

```diff
-const unsigned long MAGIC_BYTES_VX_SIZE = (unsigned long)(sizeof(MAGIC_BYTES_VX) - 1);
+const uint32_t MAGIC_BYTES_VX_SIZE = (uint32_t)(sizeof(MAGIC_BYTES_VX) - 1);
 ...
 struct MetadataBlockHeader
 {
     char  block_name[8] = { 0 };
-    unsigned long block_Length = 0;
+    uint32_t block_Length = 0;
     unsigned char hash[16] = { 0 };
     HeaderFlags flags;
     char padding[3] = { 0 };
 };
```

`MetadataBlockHeader` is read directly from disk via
`readFile(&Header, sizeof(Header))`. On Windows MSVC `unsigned long` is
**4 bytes** (LLP64); on macOS / Linux clang/gcc it is **8 bytes** (LP64).
Without this fix, `sizeof(MetadataBlockHeader)` was 36 instead of 32 on
POSIX, every subsequent file-offset was off by 4, `block_Length` came out
as garbage, and `readBlock` tried to allocate multi-petabyte buffers →
`std::bad_alloc` on the very first `-desc` of any image.

`uint32_t` matches MSVC's existing layout exactly, so this is a no-op on
Windows.

## Other patches in commit 1 (uncontroversial cross-platform shims)

- `__time64_t` → `int64_t` (Microsoft typedef vs portable fixed-width).
- `wcstombs_s` / `strerror_s` / `CoCreateGuid` → POSIX equivalents
  (`wcstombs`+UTF-8 fallback / `strerror_r` / `uuid_generate_random`)
  behind `#ifdef _WIN32`.
- `min(...)` → `std::min<uint32_t>(...)` (works whether or not the Windows
  `min` macro is in scope).
- Backslash include paths (`#include "..\foo\bar.h"`) → forward slash —
  MSVC accepts both, clang/gcc rejects backslashes.
- `<objbase.h>`, `<winioctl.h>`, `<io.h>` includes wrapped in `#ifdef _WIN32`.
- Bundled `dependencies/include/nlohmann/json.hpp` → system
  `<nlohmann/json.hpp>` on POSIX (Homebrew / apt provide it).
- zstd: `#include "./zstd/zstd.h"` on Windows (bundled), `#include <zstd.h>`
  on POSIX (system).

## Verified locally

macOS 26.5, Apple M4, AppleClang 21 + Homebrew (openssl@3, zstd, nlohmann-json):

- `./build/img_to_raw/img_to_raw demo/2394E9AA621DDC3A-00-00.mrimgx demo.raw`
  — bundled demo, 60 MB → 120 GB sparse (119 MB physical), 148 MB/s.
- A real ~40 GB `.mrimgx` backup of a Windows system disk → 466 GB sparse
  (~61 GB physical), ~9 min at 110 MB/s on a USB-C SSD.
- `mmls` / `fls -o <ntfs_sector>` / `tsk_recover -a -o <ntfs_sector>` from
  the Sleuth Kit successfully list and extract files from the resulting
  raw image (`brew install sleuthkit`).

The Windows build was not exercised in this PR's CI run — I don't have a
Windows toolchain here — but every change is either MSVC-equivalent or
behind `#ifdef _WIN32`. Welcoming a CI check or a quick reviewer build to
confirm.

## Test plan

- [ ] Windows: `cmake -B build -S src && cmake --build build` still produces
      `img_to_vhdx.exe`; demo.bat still works.
- [ ] macOS: `brew install cmake openssl@3 zstd nlohmann-json && cd src &&
      cmake -B build -S . && cmake --build build` produces
      `build/img_to_raw/img_to_raw`.
- [ ] macOS: `./build/img_to_raw/img_to_raw demo/2394E9AA621DDC3A-00-00.mrimgx -desc`
      prints the 120 GB Demo disk.
- [ ] macOS: full restore of the demo image, then `mmls demo.raw` shows the
      GPT layout and `tsk_recover -o 32768 demo.raw out/` extracts
      `readme.txt`.
- [ ] Linux: `apt install cmake libssl-dev libzstd-dev nlohmann-json3-dev uuid-dev`
      builds the same target.